### PR TITLE
refactor(classroom-attendance): Remove deprecated presence calculatio…

### DIFF
--- a/src/features/dashboard/classroom-attendance/utils/attendance-calculator.ts
+++ b/src/features/dashboard/classroom-attendance/utils/attendance-calculator.ts
@@ -162,7 +162,6 @@ function getNotInMetricLimit(): ClassroomConfigClassTypesLimitT {
     color: "#6b7280", // muted color
     allow_justification: false,
     is_presence: false,
-    presenceCalcType: "bySingleMeeting",
   };
 }
 
@@ -214,7 +213,6 @@ function getDefaultLimit(
       color: "#00ff00",
       allow_justification: false,
       is_presence: true,
-      presenceCalcType: "bySingleMeeting",
     };
   } else if (minutesAttended >= 30) {
     return {
@@ -226,7 +224,6 @@ function getDefaultLimit(
       color: "#ffff00",
       allow_justification: true,
       is_presence: false,
-      presenceCalcType: "bySingleMeeting",
     };
   } else {
     return {
@@ -238,7 +235,6 @@ function getDefaultLimit(
       color: "#ff0000",
       allow_justification: true,
       is_presence: false,
-      presenceCalcType: "bySingleMeeting",
     };
   }
 }

--- a/src/features/dashboard/classroom-overview/page.tsx
+++ b/src/features/dashboard/classroom-overview/page.tsx
@@ -131,7 +131,6 @@ export default function ClassroomAttendancePage() {
           filteredMeetings,
           studentEmail,
           currentConfig?.class_types,
-          classroomStudents
         );
 
         // Calcular scores dos testes Coodesh com dados filtrados

--- a/src/features/dashboard/classroom-overview/utils/calculate-presence-by-type.ts
+++ b/src/features/dashboard/classroom-overview/utils/calculate-presence-by-type.ts
@@ -1,6 +1,5 @@
 import {
   calculateUserAttendance,
-  calculateUserWeeklyPresence,
 } from "../../classroom-attendance/utils";
 import {
   ZoomMeetingPastInstanceT,
@@ -8,6 +7,7 @@ import {
 } from "../../classroom-zoom/types";
 import { ClassroomConfigClassTypesT } from "../../classroom-configs/types";
 import { startOfWeek } from "date-fns";
+import { calculateUserWeeklyPresence } from "../../classroom-attendance/utils/weekly-attendance-calcs";
 
 export function calculatePresenceByType(
   zoomPastInstances: ZoomMeetingPastInstanceT[],


### PR DESCRIPTION
…n properties

- Remove `presenceCalcType` from default and not-in-metric limit configurations
- Update `calculatePresenceByType` function to remove unused `classroomStudents` parameter
- Import `calculateUserWeeklyPresence` from a more specific path in attendance utils
- Simplify attendance configuration type definitions by removing unnecessary properties